### PR TITLE
fix: :bug: Correct routes from the browser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
     "presets": ["next/babel"],
-    "plugins": [["styled-components", { "ssr": true }]]
+    "plugins": [["styled-components", { "ssr": false }]]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    trailingSlash: true,
+}


### PR DESCRIPTION
@enmalidia all it tuck was this https://nextjs.org/docs/api-reference/next.config.js/exportPathMap#adding-a-trailing-slash

Now when the static site is generated, each page will be a directory containing a `index.html` file, with is what we want. For example, now the page faqs/index.html will exits an the user can go directly to `http://example.com/faqs/index.hrml` or `http://example.com/faqs/` or `http://example.com/faqs`.

Refs: datwit/landing3#84